### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/orchestrator/auth.py
+++ b/orchestrator/auth.py
@@ -32,7 +32,7 @@ def configure_flaat(settings: Settings, logger: Logger) -> None:
         logger: The logger instance for logging configuration details.
 
     """
-    logger.info("Set trusted IDPs: %s", settings.TRUSTED_IDP_LIST)
+    logger.info("Trusted IDPs have been configured. Total count: %d", len(settings.TRUSTED_IDP_LIST))
     logger.info("Authorization mode is %s", settings.AUTHZ_MODE.value)
     flaat.set_request_timeout(IDP_TIMEOUT)
     flaat.set_trusted_OP_list([str(i) for i in settings.TRUSTED_IDP_LIST])


### PR DESCRIPTION
Potential fix for [https://github.com/infn-datacloud/orchestrator-python/security/code-scanning/1](https://github.com/infn-datacloud/orchestrator-python/security/code-scanning/1)

To fix the issue, we should avoid logging the full content of `settings.TRUSTED_IDP_LIST`. Instead, we can log a sanitized or summarized version of the data, such as the count of items in the list or a generic message indicating that the trusted IDPs have been configured. This approach ensures that no sensitive information is exposed while still providing useful logging for debugging or operational purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
